### PR TITLE
Better margin for sponsor logos

### DIFF
--- a/resources/assets/sass/pages/event.sass
+++ b/resources/assets/sass/pages/event.sass
@@ -312,6 +312,9 @@ body.event.index
                     display: block
                     height: 7rem
                     width: 100%
+                    margin: 
+                        top: .8rem
+                        bottom: .8rem
                     background:
                         size: contain
                         position: 50% 50%


### PR DESCRIPTION
A lot of companies require a certain amount of empty space around their logos... currently we're not respecting that :( Feel free to change the value and I hope my syntax is correct... GL?

# Before
![image](https://user-images.githubusercontent.com/13333578/47831689-ff560e80-dd67-11e8-94bd-d12f1ce19c10.png)

# After
![image](https://user-images.githubusercontent.com/13333578/47831678-f1a08900-dd67-11e8-98a6-12d1a0af97b1.png)
